### PR TITLE
CollectionDifference: correct typo in print statement

### DIFF
--- a/_posts/2020-1-29-CollectionDifference.md
+++ b/_posts/2020-1-29-CollectionDifference.md
@@ -121,7 +121,7 @@ If we do need it, notice how we get the associations by way of `inferringMoves`.
 for update in diff.inferringMoves { /* code */ }
 
 /* Now prints
-Moved A at idx 0 and moved to 1
+Removed A at idx 0 and moved to 1
 Inserted A at idx 1 from 0
 */
 ```


### PR DESCRIPTION
Nice article! I noticed this small typo which confused me for a little bit, so thought it might be worth fixing.