### PR TITLE
Remove space that prevent YAML front matter block to be processed

### DIFF
--- a/_posts/2020-6-23-iOS-14-Notable-UIKit-Additions.md
+++ b/_posts/2020-6-23-iOS-14-Notable-UIKit-Additions.md
@@ -1,4 +1,3 @@
-
 ---
 layout: post
 tags: ["UIKit"]


### PR DESCRIPTION
The blog post is actually not rendered correctly because there is an extra space before the YAML front matter block that prevent Jekyll to process it.